### PR TITLE
Ignore IntelliJ Platform IDEs project specific settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,8 +349,11 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-
-
 # fa compile temp folder
 _build/
+
+# IntelliJ Platform IDEs project specific settings files
+*.idea
+
+# macOS File System
 .DS_Store


### PR DESCRIPTION
Ignore IntelliJ Platform IDEs project specific settings files (`.idea` directory) to prevent the problems caused by individual IDE settings when creating new PRs.